### PR TITLE
V1.1.0

### DIFF
--- a/src/SlimTwigWrapper.php
+++ b/src/SlimTwigWrapper.php
@@ -35,6 +35,7 @@ class SlimTwigWrapper
 	public function __construct()
 	{
 		$this->server = $this->encode($_SERVER);
+        $this->server['DOCUMENT_ROOT'] = __DIR__; //<-- Make sure the DOCUMENT_ROOT is the path of the main index.php file. This is mainly for those servers where the main DOCUMENT_ROOT serves multiple sites in subdirectories.
 		$this->root = dirname($this->server['SCRIPT_NAME']);
 		$parts = explode('?', $this->server['REQUEST_URI']);
 		$this->host = $this->server['HTTP_HOST'];

--- a/src/SlimTwigWrapper.php
+++ b/src/SlimTwigWrapper.php
@@ -144,7 +144,7 @@ class SlimTwigWrapper
 			}
 			return $wrapper->response;
 		};
-		return $middlewareCallback;
+		return $middlewareCall;
     }
 
 

--- a/src/SlimTwigWrapper.php
+++ b/src/SlimTwigWrapper.php
@@ -251,7 +251,7 @@ class SlimTwigWrapper
 
 		$route = $this->slim->map($methods, $path, $responseCall);
         // Check for any matching group middleware.
-        foreach ($this->groupMiddlewares as $path => $middlwareCallback) {
+        foreach ($this->groupMiddlewares as $path => $middlewareCallback) {
             if (substr($path, 0, strlen($path)) === $path) {
                 $route->add($middlewareCallback);
             }


### PR DESCRIPTION
- Allow adding middleware to specified route groups.
- Allow attaching middleware to routes.
- Update readme file.
- Typo fix.
- Allow proper path recognition for servers where the main DOCUMENT_ROOT serves multiple sites in subdirectories.
- The method makeMiddlewareCallback() was returning the wrong function.
- Typo fix.
- Have the global, group, and route middlewares execute in a similar order as how Slim does it.